### PR TITLE
ci: add permissions for GitHub Pages deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,10 @@ jobs:
     needs: ci
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- The `deploy` job in `ci.yml` was missing the `contents: read` / `pages: write` / `id-token: write` permissions that the old `deploy.yml` declared at the workflow level. Without them, `actions/deploy-pages` cannot authenticate and the push-to-main deploy added in #123 would fail.

## Test plan
- [x] Confirm a push to `main` successfully deploys to GitHub Pages