### PR TITLE
feat: deploy PR previews to gh-pages subdirectories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,24 +34,53 @@ jobs:
       - name: Build Check
         run: npm run build
 
-      - name: Install, build, and upload your site
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: withastro/action@v6
-        with:
-          node-version: 24
-
   deploy:
+    name: Deploy
     needs: ci
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      contents: write
+    concurrency:
+      group: gh-pages
+      cancel-in-progress: false
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Checkout gh-pages worktree
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin gh-pages:gh-pages 2>/dev/null \
+            && git worktree add gh-pages gh-pages \
+            || git worktree add --orphan -b gh-pages gh-pages
+
+      - name: Publish site to gh-pages
+        run: |
+          find gh-pages -mindepth 1 -maxdepth 1 \
+            ! -name '.git' \
+            ! -name 'pr-preview-*' \
+            -exec rm -rf {} +
+          cp -r dist/. gh-pages/
+          touch gh-pages/.nojekyll
+
+      - name: Commit and push
+        working-directory: gh-pages
+        run: |
+          git add .
+          git diff --staged --quiet || git commit -m "Deploy ${{ github.sha }}"
+          git push origin gh-pages

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,146 @@
+name: Preview
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened, closed]
+
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  PAGE_DIR: pr-preview-${{ github.event.pull_request.number }}
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+        env:
+          BASE_PATH: /${{ env.PAGE_DIR }}/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-preview
+          path: dist/
+          retention-days: 1
+
+  preview:
+    name: Deploy preview
+    needs: [build]
+    runs-on: ubuntu-latest
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    concurrency:
+      group: gh-pages
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Checkout or create gh-pages
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin gh-pages 2>/dev/null
+          if git rev-parse --verify origin/gh-pages >/dev/null 2>&1; then
+            git checkout gh-pages
+          else
+            git checkout --orphan gh-pages
+            git rm -rf . > /dev/null
+          fi
+
+      - name: Download artifact
+        uses: actions/download-artifact@v6
+        with:
+          name: site-preview
+          path: ${{ env.PAGE_DIR }}
+
+      - name: Commit and push
+        run: |
+          touch .nojekyll
+          git add .
+          git diff --staged --quiet || git commit -m "Deploy PR preview for #${{ github.event.pull_request.number }}"
+          git push origin gh-pages
+
+      - name: Comment PR
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const url = `https://wktk.moe/${process.env.PAGE_DIR}/`;
+            const marker = "<!-- pr-preview-comment -->";
+            const body = `${marker}\n🔍 Preview deployed to: ${url}`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            const existing = comments.find((comment) => comment.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body
+              });
+            }
+
+  cleanup:
+    name: Cleanup preview
+    runs-on: ubuntu-latest
+    if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    concurrency:
+      group: gh-pages
+      cancel-in-progress: false
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Checkout gh-pages
+        id: checkout-gh-pages
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin gh-pages 2>/dev/null || echo "skip=true" >> "$GITHUB_OUTPUT"
+          git rev-parse --verify origin/gh-pages >/dev/null 2>&1 && git checkout gh-pages || echo "skip=true" >> "$GITHUB_OUTPUT"
+
+      - name: Remove preview directory
+        if: steps.checkout-gh-pages.outputs.skip != 'true'
+        run: |
+          rm -rf "${{ env.PAGE_DIR }}"
+          git add .
+          git diff --staged --quiet || git commit -m "Remove PR preview for #${{ github.event.pull_request.number }}"
+          git push origin gh-pages

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -23,6 +23,7 @@ import rehypeExternalLinks from "rehype-external-links";
 // https://astro.build/config
 export default defineConfig({
   site: "https://wktk.moe",
+  base: process.env.BASE_PATH || "/",
   integrations: [
     partytown({
       config: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,5 +16,13 @@ export default defineConfig([
   prettier,
   {
     ignores: ["eslint.config.js"]
+  },
+  {
+    files: ["astro.config.mjs"],
+    languageOptions: {
+      globals: {
+        process: "readonly"
+      }
+    }
   }
 ]);

--- a/src/components/ArticleLink.astro
+++ b/src/components/ArticleLink.astro
@@ -20,7 +20,7 @@ const { url, title } = Astro.props;
     </div>
     <div>
       <a href={url}>
-        <img src="/arrow/right.webp" alt="" />
+        <img src={`${import.meta.env.BASE_URL}arrow/right.webp`} alt="" />
       </a>
     </div>
   </div>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -9,13 +9,13 @@ import { REPOSITORY } from "../consts";
   <div class="main bg-white">
     <div class="main-contents">
       <div>
-        <a href="/">
+        <a href={import.meta.env.BASE_URL}>
           <h1 class="title">Wktk.moe</h1>
         </a>
-        <a href="/about">
+        <a href={`${import.meta.env.BASE_URL}about`}>
           <h1 class="link">About</h1>
         </a>
-        <a href="/articles">
+        <a href={`${import.meta.env.BASE_URL}articles`}>
           <h1 class="link">Articles</h1>
         </a>
       </div>

--- a/src/components/Link.astro
+++ b/src/components/Link.astro
@@ -11,7 +11,7 @@ const { url, title, icon } = Astro.props;
 <a class="block" href={url} target="_blank" rel="noopener noreferrer">
   <div class="layout">
     <div class="link-icon">
-      <img loading="lazy" src={icon} alt="" />
+      <img loading="lazy" src={`${import.meta.env.BASE_URL}${icon.replace(/^\//, "")}`} alt="" />
     </div>
     <div class="info">
       <p>{title}</p>

--- a/src/components/Profile.astro
+++ b/src/components/Profile.astro
@@ -51,7 +51,7 @@ const shortInMobile = Astro.props.shortInMobile ?? true;
 </div>
 <div class={`sub-head ${shortInMobile ? "about-link" : "hidden"}`}>
   <p>
-    <a href="/about">詳細を閲覧</a>
+    <a href={`${import.meta.env.BASE_URL}about`}>詳細を閲覧</a>
   </p>
 </div>
 

--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -20,6 +20,7 @@ import "@pagefind/default-ui/css/ui.css";
   import { PagefindUI } from "@pagefind/default-ui";
 
   new PagefindUI({
-    element: "#search"
+    element: "#search",
+    bundlePath: `${import.meta.env.BASE_URL}pagefind/`
   });
 </script>

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -46,7 +46,7 @@ const editUrl = new URL(
       </ContentsBlock>
       <ContentsBlock>
         <div>
-          <p>その他の記事は<strong><a href="/articles">こちら</a></strong></p>
+          <p>その他の記事は<strong><a href={`${import.meta.env.BASE_URL}articles`}>こちら</a></strong></p>
           <p>
             編集は
             <strong>

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -47,8 +47,8 @@ const editUrl = new URL(
       <ContentsBlock>
         <div>
           <p>
-            その他の記事は<strong
-              ><a href={`${import.meta.env.BASE_URL}articles`}>こちら</a></strong>
+            その他の記事は<strong><a href={`${import.meta.env.BASE_URL}articles`}>こちら</a></strong
+            >
           </p>
           <p>
             編集は

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -46,7 +46,10 @@ const editUrl = new URL(
       </ContentsBlock>
       <ContentsBlock>
         <div>
-          <p>その他の記事は<strong><a href={`${import.meta.env.BASE_URL}articles`}>こちら</a></strong></p>
+          <p>
+            その他の記事は<strong
+              ><a href={`${import.meta.env.BASE_URL}articles`}>こちら</a></strong>
+          </p>
           <p>
             編集は
             <strong>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -18,7 +18,7 @@ const { title, description, keywords, color } = Astro.props;
 <html lang="ja">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}favicon.ico`} />
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
 

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -13,7 +13,7 @@ const title = "Page Not Found";
           <h1 class="title">{title}</h1>
         </div>
         <div>
-          <p><a href="/">こちら</a>からホームに戻れます。</p>
+          <p><a href={import.meta.env.BASE_URL}>こちら</a>からホームに戻れます。</p>
         </div>
       </div>
     </ContentsBlock>

--- a/src/pages/articles/index.astro
+++ b/src/pages/articles/index.astro
@@ -16,7 +16,9 @@ const articles = await getCollection("articles");
     <div>
       {
         articles.map(({ data, id }) =>
-          !data.draft ? <ArticleLink title={data.title} url={`/articles/${id}`} /> : null
+          !data.draft ? (
+            <ArticleLink title={data.title} url={`${import.meta.env.BASE_URL}articles/${id}`} />
+          ) : null
         )
       }
     </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -26,11 +26,15 @@ const articles = (await getCollection("articles"))
     <div class="left">
       {
         articles.map(({ data, id }) =>
-          !data.draft ? <ArticleLink title={data.title} url={`/articles/${id}`} /> : null
+          !data.draft ? (
+            <ArticleLink title={data.title} url={`${import.meta.env.BASE_URL}articles/${id}`} />
+          ) : null
         )
       }
       <ContentsBlock>
-        <p class="other-article text-center"><a href="/articles">他の記事も見る</a></p>
+        <p class="other-article text-center">
+          <a href={`${import.meta.env.BASE_URL}articles`}>他の記事も見る</a>
+        </p>
       </ContentsBlock>
     </div>
   </div>

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -11,7 +11,7 @@ export async function GET(context) {
     site: context.site,
     items: posts.map(({ data, id }) => ({
       ...data,
-      link: `/articles/${id}`
+      link: `${import.meta.env.BASE_URL}articles/${id}`
     }))
   });
 }


### PR DESCRIPTION
## Summary
- Switch the production deploy from `actions/deploy-pages` to committing the build to the `gh-pages` branch root (via `.github/workflows/ci.yml`), so the branch can also host PR previews as subdirectories.
- Add `.github/workflows/preview.yml`, modeled on [ThunLights/distopia](https://github.com/ThunLights/distopia)'s `preview.yml`: on PR open/sync/reopen it builds the site with Astro's `base` set to `/pr-preview-<number>/`, publishes it to `gh-pages/pr-preview-<number>/`, and comments the preview URL on the PR; on PR close it removes the preview directory.
- Add `base: process.env.BASE_PATH || "/"` to `astro.config.mjs`, and switch every hardcoded internal `href`/`src` (`Header`, `Link`, `Profile`, `ArticleLink`, `Layout`, `BlogLayout`, `404`, `index`, `articles/index`, `rss.xml.js`, pagefind's `bundlePath`) to `import.meta.env.BASE_URL` so pages/assets resolve correctly under a preview subdirectory as well as at the site root.
- Both `gh-pages`-writing jobs (main deploy and preview/cleanup) share a `gh-pages` concurrency group to avoid racing pushes to the branch.
- Fork PRs are skipped (no write access to push previews).

## Follow-up (manual, after merge)
GitHub Pages is currently configured as "Deploy from GitHub Actions" (`build_type: workflow`). Once this is merged and a push to `main` has populated the `gh-pages` branch, the repo's Pages source needs to be switched to "Deploy from a branch: `gh-pages` / `(root)`" in Settings → Pages (or via `gh api -X PUT repos/ro80t/website/pages`) for the site — and the PR preview links — to actually go live.

## Test plan
- [x] `npm run build` succeeds with default base (`/`)
- [x] `BASE_PATH=/pr-preview-42/ npx astro build` produces correctly prefixed links/assets (verified by inspecting generated HTML)
- [x] `npm run lint`
- [ ] Confirm a push to `main` populates the `gh-pages` branch root correctly
- [ ] Confirm opening a PR posts a working preview link and closing it removes the preview directory